### PR TITLE
Clean up test and block naming for better readability

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const rm = require('rimraf').sync;
 module.exports = async (fileName, debug) => {
   const { codeArray, importsArray } = parseFile(fileName);
   try {
-    fs.writeFileSync('test.js', getCode(codeArray, importsArray));
+    fs.writeFileSync('test.js', getCode(codeArray, importsArray, fileName));
     await executeTests();
   } finally {
     if(!debug) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -84,13 +84,13 @@ function getAssertion({ code, assertion, expected }) {
   let assertionLine = '';
   switch (assertion) {
     case 'equals':
-      assertionLine = `it('${code.replace(/'/g, "\\'")}', assert => { assert.equal(${code}, ${expected}); });`;
+      assertionLine = `it('${gaurdSingleQuote(code)}', assert => { assert.equal(${code}, ${expected}); });`;
       break;
     case 'not-equals':
-      assertionLine = `it('${code.replace(/'/g, "\\'")}', assert => { assert.notEqual(${code}, ${expected}); });`;
+      assertionLine = `it('${gaurdSingleQuote(code)}', assert => { assert.notEqual(${code}, ${expected}); });`;
       break;
     case 'throws':
-      assertionLine = `it('${code.replace(/'/g, "\\'")}', assert => { assert.throws(() => { throw ${code} }, 'Throws error'); });`;
+      assertionLine = `it('${gaurdSingleQuote(code)}', assert => { assert.throws(() => { throw ${code} }, 'Throws error'); });`;
       break;
     default:
       break;
@@ -104,7 +104,7 @@ function getCode(codeArray, importsArray, fileName) {
   fileContent += `
   const describe = QUnit.module;
   const it = QUnit.test;
-  describe('${fileName}', () => {
+  describe('${gaurdSingleQuote(fileName)}', () => {
   `
   codeArray.forEach((element) => {
     let assertion = getAssertionComponents(element);
@@ -129,6 +129,10 @@ function getCode(codeArray, importsArray, fileName) {
   return generatedCode.code;
 }
 
+function gaurdSingleQuote(str) {
+  return str.replace(/'/g, "\\'");
+}
+
 function cleanUpAssertion(element) {
   return element.replace(";", "");
 }
@@ -147,4 +151,4 @@ async function executeTests() {
   console.log(stdout);
 }
 
-module.exports = { parseFile, parseImport, getAssertionComponents, getCode, getAssertion, executeTests, checkDupAndAddToList, parseCode, checkIfJS };
+module.exports = { parseFile, parseImport, getAssertionComponents, getCode, getAssertion, executeTests, checkDupAndAddToList, parseCode, checkIfJS, gaurdSingleQuote };

--- a/lib/util.js
+++ b/lib/util.js
@@ -84,27 +84,27 @@ function getAssertion({ code, assertion, expected }) {
   let assertionLine = '';
   switch (assertion) {
     case 'equals':
-      assertionLine = `assert.equal(${code}, ${expected});`;
+      assertionLine = `it('${code.replace(/'/g, "\\'")}', assert => { assert.equal(${code}, ${expected}); });`;
       break;
     case 'not-equals':
-      assertionLine = `assert.notEqual(${code}, ${expected});`;
+      assertionLine = `it('${code.replace(/'/g, "\\'")}', assert => { assert.notEqual(${code}, ${expected}); });`;
       break;
     case 'throws':
-      assertionLine = `assert.throws(() => { throw ${code} }, 'Throws error');`;
+      assertionLine = `it('${code.replace(/'/g, "\\'")}', assert => { assert.throws(() => { throw ${code} }, 'Throws error'); });`;
+      break;
     default:
       break;
   }
   return `${assertionLine}\n`;
 }
 
-function getCode(codeArray, importsArray) {
+function getCode(codeArray, importsArray, fileName) {
   let fileContent = '', assertCount = 0;
   fileContent = importsArray.join('\n');
   fileContent += `
   const describe = QUnit.module;
   const it = QUnit.test;
-  describe('Test the doc', () => {
-    it('samples', assert => {
+  describe('${fileName}', () => {
   `
   codeArray.forEach((element) => {
     let assertion = getAssertionComponents(element);
@@ -119,9 +119,7 @@ function getCode(codeArray, importsArray) {
     }
   });
 
-  fileContent += `assert.expect(${assertCount});`
   fileContent +=`
-    });
   });`
   const generatedCode = transformSync(fileContent, {
     "presets": [

--- a/tests/unit-test.js
+++ b/tests/unit-test.js
@@ -1,7 +1,7 @@
 const describe = QUnit.module;
 const it = QUnit.test;
 const done = QUnit.testDone;
-const { parseFile, parseImport, getAssertionComponents, getCode, getAssertion, checkDupAndAddToList, parseCode, checkIfJS } = require('../lib/util');
+const { parseFile, parseImport, getAssertionComponents, getCode, getAssertion, checkDupAndAddToList, parseCode, checkIfJS, gaurdSingleQuote } = require('../lib/util');
 const fixture = require('fixturify');
 const rm = require('rimraf').sync;
 
@@ -170,6 +170,14 @@ describe('Util:', () => {
       assert.notOk(checkIfJS('sh'), 'sh');
       assert.notOk(checkIfJS('JAVA'), 'JAVA');
       assert.notOk(checkIfJS('python'), 'python');
+    });
+  });
+  describe('gaurdSingleQuote', () =>{
+    it('gaurds string', assert => {
+      assert.equal(gaurdSingleQuote("String's problems"), `String\\'s problems`);
+    });
+    it('Nothing to gaurd', assert => {
+      assert.equal(gaurdSingleQuote("String problems"), `String problems`);
     });
   });
 });


### PR DESCRIPTION
```
Not all tests passed: 
Error: Command failed: node node_modules/.bin/qunit test.js

TAP version 13
ok 1 README.md > add(4, 5)
ok 2 README.md > add(4, 5)
ok 3 README.md > add(2, 3)
ok 4 README.md > subtract(numbers.a, numbers.b)
not ok 5 README.md > add( {  a: 4}.a, 4)
  ---
  message: "failed"
  severity: failed
  actual: 8
  expected: 9
  stack:     at Object.<anonymous> (/Users/snrai/Projects/doc-tester/test.js:27:12)
  ...
1..5
# pass 4
# skip 0
# todo 0
# fail 1


~/Projects/doc-tester  test-refactor ✗                                                                                                                                                                                           0m ⚑  ⍉
▶ bin/doc-test
TAP version 13
ok 1 README.md > add(4, 5)
ok 2 README.md > add(4, 5)
ok 3 README.md > add(2, 3)
ok 4 README.md > subtract(numbers.a, numbers.b)
ok 5 README.md > add( {  a: 4}.a, 4)
1..5
# pass 5
# skip 0
# todo 0
# fail 0
```